### PR TITLE
Add training script and checkpoint configuration

### DIFF
--- a/run.py
+++ b/run.py
@@ -22,6 +22,8 @@ parser.add_argument('--weight_decay', default=0.0, type=float)
 parser.add_argument('--max_grad_norm', default=1.0, type=float)
 parser.add_argument('--min_num', default=1e-7, type=float)
 parser.add_argument('--base_path', default="./dataset", type=str)
+parser.add_argument('--output_path', default="./ckpt", type=str)
+parser.add_argument('--save_interval', default=1, type=int)
 
 args = parser.parse_args()
 

--- a/train.sh
+++ b/train.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+usage() {
+  cat <<USAGE
+Usage: $0 -d DATASET [-r ROUNDS] [-g GPU_ID] [-o OUTPUT_PATH] [-s SAVE_INTERVAL]
+
+Available DATASET options (default rounds):
+  WebNLG       (rounds=4)
+  WebNLG_star  (rounds=2)
+  NYT24        (rounds=3)
+  NYT24_star   (rounds=2)
+  NYT29        (rounds=3)
+USAGE
+}
+
+# default parameters，可在此处直接修改
+dataset="WebNLG"
+rounds=4
+gpu_id=0
+output_path=./ckpt
+save_interval=1
+
+# 标记是否通过参数传入 dataset 或 rounds
+dataset_cli=0
+rounds_cli=0
+
+while getopts "d:r:g:o:s:h" opt; do
+  case ${opt} in
+    d) dataset=${OPTARG}; dataset_cli=1 ;;
+    r) rounds=${OPTARG}; rounds_cli=1 ;;
+    g) gpu_id=${OPTARG} ;;
+    o) output_path=${OPTARG} ;;
+    s) save_interval=${OPTARG} ;;
+    h) usage; exit 0 ;;
+    *) usage; exit 1 ;;
+  esac
+done
+
+# 根据传入的数据集设置默认轮数
+if [ ${dataset_cli} -eq 1 ] && [ ${rounds_cli} -eq 0 ]; then
+  case ${dataset} in
+    WebNLG) rounds=4 ;;
+    WebNLG_star) rounds=2 ;;
+    NYT24) rounds=3 ;;
+    NYT24_star) rounds=2 ;;
+    NYT29) rounds=3 ;;
+    *) echo "Unknown dataset: ${dataset}" >&2; usage; exit 1 ;;
+  esac
+else
+  case ${dataset} in
+    WebNLG|WebNLG_star|NYT24|NYT24_star|NYT29) ;;
+    *) echo "Unknown dataset: ${dataset}" >&2; usage; exit 1 ;;
+  esac
+fi
+
+CUDA_VISIBLE_DEVICES=${gpu_id} python -u run.py \
+  --cuda_id=${gpu_id} \
+  --dataset=${dataset} \
+  --train=train \
+  --rounds=${rounds} \
+  --output_path="${output_path}" \
+  --save_interval=${save_interval}
+


### PR DESCRIPTION
## Summary
- add train.sh with dataset selection, GPU configuration, and default dataset/round settings
- support configurable output_path and checkpoint interval in run.py and main.py
- save model checkpoints every N epochs and track best_model

## Testing
- `python -m py_compile run.py main.py`
- `bash train.sh -h`


------
https://chatgpt.com/codex/tasks/task_e_68bc547f5bc48325acd1040f298eea1d