### PR TITLE
feat: add model loading and test script

### DIFF
--- a/main.py
+++ b/main.py
@@ -122,7 +122,7 @@ def train(args):
         torch.cuda.set_device(int(args.cuda_id))
     except:
         os.environ["CUDA_VISIBLE_DEVICES"] =args.cuda_id
-    output_path=os.path.join(args.output_path,args.dataset,args.file_id)
+    output_path=os.path.join(args.output_path, args.dataset)
     train_path=os.path.join(args.base_path,args.dataset,"train.json")
     dev_path=os.path.join(args.base_path,args.dataset,"dev.json")
     test_path=os.path.join(args.base_path,args.dataset,"test.json")
@@ -153,6 +153,11 @@ def train(args):
 
     train_model = GRTE.from_pretrained(pretrained_model_name_or_path=args.bert_model_path,config=config)
     train_model.to("cuda")
+
+    if getattr(args, "load_model", False):
+        best_model = os.path.join(output_path, "best_model.bin")
+        if os.path.exists(best_model):
+            train_model.load_state_dict(torch.load(best_model, map_location="cuda"))
 
     if not os.path.exists(output_path):
         os.makedirs(output_path)
@@ -363,7 +368,7 @@ def test(args):
     except:
         os.environ["CUDA_VISIBLE_DEVICES"] =args.cuda_id
 
-    output_path=os.path.join(args.output_path,args.dataset,args.file_id)
+    output_path=os.path.join(args.output_path, args.dataset)
 
     dev_path=os.path.join(args.base_path,args.dataset,"dev.json")
     test_path=os.path.join(args.base_path,args.dataset,"test.json")

--- a/run.py
+++ b/run.py
@@ -9,7 +9,6 @@ parser.add_argument('--train', default="train", type=str)
 
 parser.add_argument('--batch_size', default=6, type=int)
 parser.add_argument('--test_batch_size', default=6, type=int)
-parser.add_argument('--file_id', default="99", type=str)
 parser.add_argument('--learning_rate', default=3e-5, type=float)
 parser.add_argument('--num_train_epochs', default=50, type=int)
 parser.add_argument('--fix_bert_embeddings', default=False, type=bool)
@@ -24,6 +23,7 @@ parser.add_argument('--min_num', default=1e-7, type=float)
 parser.add_argument('--base_path', default="./dataset", type=str)
 parser.add_argument('--output_path', default="./ckpt", type=str)
 parser.add_argument('--save_interval', default=1, type=int)
+parser.add_argument('--load_model', action='store_true')
 
 args = parser.parse_args()
 

--- a/util.py
+++ b/util.py
@@ -7,7 +7,7 @@ import pickle
 import torch
 
 def print_config(args):
-    config_path=os.path.join(args.base_path, args.dataset, "output", args.file_id,"config.txt")
+    config_path=os.path.join(args.base_path, args.dataset, "output", "config.txt")
     with open(config_path,"w",encoding="utf-8") as f:
         for k,v in sorted(vars(args).items()):
             print(k,'=',v,file=f)


### PR DESCRIPTION
## Summary
- enable optional checkpoint loading before training
- add dataset-based testing helper script
- simplify checkpoint paths by removing file_id layer

## Testing
- `bash train.sh -h`
- `bash test.sh -h`


------
https://chatgpt.com/codex/tasks/task_e_68bc5df06b788325a272d2cf9ea4fac6