### PR TITLE
默认日志级别改为 INFO

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -34,4 +34,4 @@ label_list:
   - "MST"
 
 logging:
-  level: "DEBUG"
+  level: "INFO"

--- a/util.py
+++ b/util.py
@@ -24,8 +24,8 @@ def load_config(config_path):
 def setup_logger(config=None):
     config = config or {}
     log_config = config.get("logging", {})
-    level_name = log_config.get("level", "DEBUG")
-    level = getattr(logging, level_name.upper(), logging.DEBUG)
+    level_name = log_config.get("level", "INFO")
+    level = getattr(logging, level_name.upper(), logging.INFO)
     logger = logging.getLogger("grte")
     if not logger.handlers:
         handler = logging.StreamHandler()


### PR DESCRIPTION
### Motivation
- 避免在默认运行中输出大量调试信息，将默认日志级别提高到 `INFO` 以减少噪声。
- 保留混合预测/混合评估相关的详细信息为 `DEBUG`，仅在需要调试时启用。

### Description
- 将 `util.py` 中 `setup_logger` 的默认回退级别从 `DEBUG` 调整为 `INFO`（修改 `level_name` 与 `level` 的默认值）。
- 将 `config.yaml` 中 `logging.level` 的默认值从 `DEBUG` 更新为 `INFO`。 

### Testing
- 运行 `python - <<'PY' ...` 调用 `load_config` 与 `setup_logger` 以验证日志级别行为，但执行失败并报 `ModuleNotFoundError: No module named 'numpy'`（自动化测试未通过因为缺少依赖）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696635f158e88325a96ee7df168e9c12)