### PR TITLE
为测试评估增加每条样本日志与可配置预览

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -35,3 +35,6 @@ label_list:
 
 logging:
   level: "INFO"
+  sample_log: true
+  sample_text_max_len: 200
+  sample_triple_max_len: 200

--- a/util.py
+++ b/util.py
@@ -37,6 +37,13 @@ def setup_logger(config=None):
     logger.setLevel(level)
     return logger
 
+
+def format_preview(value, max_len=200):
+    text = str(value)
+    if max_len and len(text) > max_len:
+        return f"{text[:max_len]}...(len={len(text)})"
+    return text
+
 def print_config(args):
     config_path = os.path.join(args.base_path, args.dataset, "output", "config.txt")
     os.makedirs(os.path.dirname(config_path), exist_ok=True)


### PR DESCRIPTION
### Motivation
- 在评估流程中按样本打印输入、模型预测、正确答案及本次使用来源，方便定位单条样本问题并提高调试可见性。 
- 将预览/截断逻辑复用成工具函数并把显示开关与长度等静态配置写入 `config.yaml` 以便前端/运维控制。

### Description
- 在 `util.py` 新增 `format_preview` 函数用于将任意值格式化并截断预览输出。 
- 在 `main.py` 的 `evaluate` 中改为先加载 `app_config` 并通过 `setup_logger(app_config)` 初始化日志，增加从配置读取 `sample_log`、`sample_text_max_len`、`sample_triple_max_len` 的逻辑；在遍历评估样本时维护 `sample_index` 并在 `eval_mode == "test"` 时通过 `logger.info` 打印每条样本的 `n/m`、输入、正确答案、模型预测以及本次使用（来自 groundtruth 还是 model）。
- 在 `config.yaml` 增加默认日志配置项 `sample_log`, `sample_text_max_len`, `sample_triple_max_len`，并保持默认开启。 
- 修改文件：`main.py`, `util.py`, `config.yaml`。 

### Testing
- 运行简单 snippet 测试 `format_preview`：
  - `python - <<'PY'\nfrom util import format_preview\nprint(format_preview('a'*10, 5))\nprint(format_preview(['x','y'], 50))\nPY`（失败，环境缺少 `numpy` 导致 `ModuleNotFoundError`，因此无法在当前环境执行该片段）。
- 代码变更已成功添加并提交（`git commit` 成功），未发现语法错误；未运行完整模型评估/训练的端到端自动化测试。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967a1393d088325be286c6aa5e13994)